### PR TITLE
Add TFLite export utility

### DIFF
--- a/torchDF/README.md
+++ b/torchDF/README.md
@@ -17,7 +17,7 @@ poetry install
 poe install-torch-cpu
 ```
 
-Here is presented offline and streaming implementation of DeepFilterNet3 on pure torch. Streaming model can be fully exported to ONNX using `model_onnx_export.py`.
+Here is presented offline and streaming implementation of DeepFilterNet3 on pure torch. Streaming model can be fully exported to ONNX using `model_onnx_export.py` and then converted to TensorFlow Lite with `model_tflite_export.py`.
 
 Every script and test have to run inside poetry enviroment.
 
@@ -35,6 +35,7 @@ poetry run python torch_df_streaming_minimal.py --audio-path examples/A1CIM28ZUC
 To convert model to onnx and run tests:
 ```
 poetry run python model_onnx_export.py --test --performance --inference-path examples/A1CIM28ZUCA8RX_M_Street_Near_Regular_SP_Mobile_Primary.wav --ort --simplify --profiling --minimal
+poetry run python model_tflite_export.py denoiser_model.onnx denoiser_model.tflite --optimizations DEFAULT
 ```
 
 I also changed the hop_size parameter from 480 to 512 to speed up the stft. And then finetuned 3 epoches to adapt the model to size 512. New fast model can be found in `models/` dir.  
@@ -54,6 +55,7 @@ How to convert new model to onnx:
 # cd torchDF
 unzip ../models/DeepFilterNet3_torchDF.zip -d ../models/
 python model_onnx_export.py --performance --minimal --simplify --ort --model-base-dir ../models/DeepFilterNet3_torchDF
+python model_tflite_export.py ../models/DeepFilterNet3_torchDF_onnx/denoiser_model.onnx ../models/DeepFilterNet3_torchDF_onnx/denoiser_model.tflite --optimizations DEFAULT
 ```
 
 

--- a/torchDF/model_tflite_export.py
+++ b/torchDF/model_tflite_export.py
@@ -1,0 +1,55 @@
+import argparse
+import tempfile
+import onnx
+from onnx_tf.backend import prepare
+import tensorflow as tf
+
+
+def convert_onnx_to_tflite(onnx_path: str, tflite_path: str, optimizations=None) -> str:
+    """Convert an ONNX model to TensorFlow Lite format."""
+    model = onnx.load(onnx_path)
+    tf_rep = prepare(model)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tf_rep.export_graph(tmpdir)
+        converter = tf.lite.TFLiteConverter.from_saved_model(tmpdir)
+        if optimizations:
+            converter.optimizations = optimizations
+        tflite_model = converter.convert()
+    with open(tflite_path, "wb") as f:
+        f.write(tflite_model)
+    return tflite_path
+
+
+def _parse_opts(opts: str):
+    if not opts:
+        return None
+    opts_map = {
+        "DEFAULT": tf.lite.Optimize.DEFAULT,
+        "SIZE": tf.lite.Optimize.OPTIMIZE_FOR_SIZE,
+        "LATENCY": tf.lite.Optimize.OPTIMIZE_FOR_LATENCY,
+    }
+    results = []
+    for name in opts.split(','):
+        key = name.strip().upper()
+        if key:
+            if key not in opts_map:
+                raise ValueError(f"Unknown optimization flag: {name}")
+            results.append(opts_map[key])
+    return results
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Convert ONNX model to TFLite")
+    parser.add_argument("onnx_path", help="Path to source ONNX model")
+    parser.add_argument("tflite_path", help="Destination path for TFLite model")
+    parser.add_argument(
+        "--optimizations",
+        help="Comma separated list of optimizations: DEFAULT,SIZE,LATENCY",
+    )
+    args = parser.parse_args()
+    opts = _parse_opts(args.optimizations)
+    convert_onnx_to_tflite(args.onnx_path, args.tflite_path, opts)
+
+
+if __name__ == "__main__":
+    main()

--- a/torchDF/pyproject.toml
+++ b/torchDF/pyproject.toml
@@ -44,6 +44,8 @@ onnx = "^1.14.0"
 onnxsim = "^0.4.33"
 onnxscript = "^0.1.0.dev20240131"
 onnxruntime-extensions = "^0.10.0"
+tensorflow = "^2.13"
+onnx-tf = "^1.10"
 
 [tool.poetry.extras]
 train = ["deepfilterdataloader", "icecream"]


### PR DESCRIPTION
## Summary
- support conversion of the ONNX model to TFLite
- describe conversion workflow in README
- include tensorflow and onnx-tf dependencies

## Testing
- `poetry run python -m pytest -v` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_6847ce6fbe548326bcf08b30a0227ce1