### PR TITLE
Add TFLite export and equivalence test

### DIFF
--- a/torchDF/model_tflite_export.py
+++ b/torchDF/model_tflite_export.py
@@ -5,9 +5,43 @@ from onnx_tf.backend import prepare
 import tensorflow as tf
 
 
+def sanitize_model(model: onnx.ModelProto) -> onnx.ModelProto:
+    """Sanitize ONNX names so TensorFlow accepts them."""
+
+    def clean(name: str) -> str:
+        return name.lstrip("/").replace("/", "_")
+
+    name_map = {}
+    # Initializers
+    for init in model.graph.initializer:
+        new_name = clean(init.name)
+        if new_name != init.name:
+            name_map[init.name] = new_name
+            init.name = new_name
+    # Value infos (inputs/outputs/intermediate)
+    for vi in list(model.graph.input) + list(model.graph.output) + list(model.graph.value_info):
+        new_name = clean(vi.name)
+        if new_name != vi.name:
+            name_map[vi.name] = new_name
+            vi.name = new_name
+    # Nodes
+    for node in model.graph.node:
+        node.name = clean(node.name)
+        node.input[:] = [name_map.get(i, clean(i)) for i in node.input]
+        node.output[:] = [name_map.get(o, clean(o)) for o in node.output]
+    return model
+
+
 def convert_onnx_to_tflite(onnx_path: str, tflite_path: str, optimizations=None) -> str:
     """Convert an ONNX model to TensorFlow Lite format."""
     model = onnx.load(onnx_path)
+    from onnx import version_converter
+
+    try:
+        model = version_converter.convert_version(model, 15)
+    except Exception:
+        pass
+    model = sanitize_model(model)
     tf_rep = prepare(model)
     with tempfile.TemporaryDirectory() as tmpdir:
         tf_rep.export_graph(tmpdir)
@@ -29,7 +63,7 @@ def _parse_opts(opts: str):
         "LATENCY": tf.lite.Optimize.OPTIMIZE_FOR_LATENCY,
     }
     results = []
-    for name in opts.split(','):
+    for name in opts.split(","):
         key = name.strip().upper()
         if key:
             if key not in opts_map:

--- a/torchDF/test_tflite_export.py
+++ b/torchDF/test_tflite_export.py
@@ -1,0 +1,48 @@
+import tempfile
+import tarfile
+import os
+import numpy as np
+import onnx
+import onnxruntime as ort
+import tensorflow as tf
+
+from model_tflite_export import sanitize_model, convert_onnx_to_tflite
+
+
+def _random_inputs(model: onnx.ModelProto):
+    inputs = {}
+    for inp in model.graph.input:
+        dims = [d.dim_value if d.dim_value > 0 else 1 for d in inp.type.tensor_type.shape.dim]
+        dtype = onnx.mapping.TENSOR_TYPE_TO_NP_TYPE[inp.type.tensor_type.elem_type]
+        inputs[inp.name] = np.random.rand(*dims).astype(dtype)
+    return inputs
+
+
+def test_onnx_tflite_equivalence():
+    tar_path = "../models/DeepFilterNet3_torchDF_onnx.tar"
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with tarfile.open(tar_path) as tar:
+            tar.extractall(tmpdir)
+        onnx_path = os.path.join(tmpdir, "DeepFilterNet3_torchDF_onnx", "denoiser_model.onnx")
+        model = sanitize_model(onnx.load(onnx_path))
+        sanitized_onnx = os.path.join(tmpdir, "model.onnx")
+        tflite_path = os.path.join(tmpdir, "model.tflite")
+        onnx.save(model, sanitized_onnx)
+        convert_onnx_to_tflite(sanitized_onnx, tflite_path)
+
+        inputs = _random_inputs(model)
+
+        session = ort.InferenceSession(sanitized_onnx, providers=["CPUExecutionProvider"])
+        onnx_outputs = session.run(None, inputs)
+
+        interpreter = tf.lite.Interpreter(model_path=tflite_path)
+        interpreter.allocate_tensors()
+        for detail in interpreter.get_input_details():
+            interpreter.set_tensor(detail["index"], inputs[detail["name"]])
+        interpreter.invoke()
+        tflite_outputs = [
+            interpreter.get_tensor(detail["index"]) for detail in interpreter.get_output_details()
+        ]
+
+        for o, t in zip(onnx_outputs, tflite_outputs):
+            assert np.allclose(o, t, atol=1e-3)


### PR DESCRIPTION
## Summary
- sanitize ONNX graph names and downgrade opset for TFLite conversion
- add test exercising ONNX-to-TFLite export and comparing outputs

## Testing
- `pytest test_tflite_export.py::test_onnx_tflite_equivalence -q` *(fails: NotImplementedError: Identity version 16 is not implemented)*

------
https://chatgpt.com/codex/tasks/task_e_68988b5d15488326b63ed04219455ec4